### PR TITLE
added Ignore and Hidden attributes

### DIFF
--- a/src/QuickForm/Attributes/HiddenAttribute.cs
+++ b/src/QuickForm/Attributes/HiddenAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace QuickForm.Attributes;
+
+/// <summary>
+/// For attributes that have an input field, but should not be displayed.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class HiddenAttribute : Attribute
+{
+}

--- a/src/QuickForm/Attributes/IgnoreAttribute.cs
+++ b/src/QuickForm/Attributes/IgnoreAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace QuickForm.Attributes;
+
+/// <summary>
+/// For attributes that don't have NotMapped, but still need to be ignored.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class IgnoreAttribute : Attribute
+{
+}

--- a/src/QuickForm/Components/IQuickFormField.cs
+++ b/src/QuickForm/Components/IQuickFormField.cs
@@ -42,4 +42,12 @@ public interface IQuickFormField
     /// the string parameter is the class to be applied to the input element.
     /// </note>
     public RenderFragment<string> ValidationMessages { get; }
+
+    /// <summary>
+    /// Gets if the input together with its label and everything else should be hidden.
+    /// </summary>
+    /// <note>
+    /// The input element will still be rendered, but it will be hidden.
+    /// </note>
+    public bool IsHidden { get; }
 }

--- a/src/QuickForm/Components/QuickForm.razor
+++ b/src/QuickForm/Components/QuickForm.razor
@@ -18,7 +18,16 @@
 
     @foreach (var field in Fields)
     {
-        @ChildContent(field)
+        if (field.IsHidden)
+        {
+            <div style="display:none">
+                @ChildContent(field)
+            </div>
+        }
+        else
+        {
+            @ChildContent(field)
+        }
     }
 
     @if (SubmitButtonTemplate is not null)

--- a/src/QuickForm/Components/QuickFormField.cs
+++ b/src/QuickForm/Components/QuickFormField.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using QuickForm.Attributes;
 using QuickForm.Internal;
 
 namespace QuickForm.Components;
@@ -18,6 +19,8 @@ internal sealed class QuickFormField<TEntity> : IQuickFormField
     public string? Description => PropertyInfo.Description();
 
     public string? ValidFeedback => PropertyInfo.ValidFeedbackText();
+
+    public bool IsHidden => PropertyInfo.GetCustomAttribute<HiddenAttribute>() is not null;
 
     public RenderFragment<string> InputComponent
     {
@@ -142,6 +145,7 @@ internal sealed class QuickFormField<TEntity> : IQuickFormField
         return typeof(TEntity)
             .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
             .Where(prop => prop.GetCustomAttribute<NotMappedAttribute>() is null)
+            .Where(prop => prop.GetCustomAttribute<IgnoreAttribute>() is null)
             .Select(prop => new QuickFormField<TEntity>(form, prop));
     }
 }

--- a/test/QuickForm.Example/Properties/launchSettings.json
+++ b/test/QuickForm.Example/Properties/launchSettings.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:443;http://localhost:80",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": false,
+        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+        "applicationUrl": "https://localhost:443;http://localhost:80",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }


### PR DESCRIPTION
Ignore attribute allows properties that are included in the model (and mapped) can be still ignored during form generation.
Hidden attribute allows hiding properties on the form, although they are still generated.